### PR TITLE
Potential fix for code scanning alert no. 14: Use of externally-controlled format string

### DIFF
--- a/src/utils/sports-api.ts
+++ b/src/utils/sports-api.ts
@@ -120,7 +120,7 @@ export const getMatchStreams = async (source: string | null, id: string): Promis
           console.warn(`No streams found for source ${src} and match ${id}`);
         }
       } catch (error) {
-        console.error(`Error fetching streams for match ${id} from source ${src}:`, error);
+        console.error('Error fetching streams for match %s from source %s:', id, src, error);
       }
     }
     return allStreams;


### PR DESCRIPTION
Potential fix for [https://github.com/chintan992/letsstream2/security/code-scanning/14](https://github.com/chintan992/letsstream2/security/code-scanning/14)

To fix the issue, we will ensure that the untrusted variables `id` and `src` are passed as separate arguments to `console.error` using a `%s` format specifier. This approach prevents any unintended interpretation of the variables as format specifiers. Specifically:
1. Replace the template literal in the `console.error` call with a format string using `%s` placeholders.
2. Pass the untrusted variables (`id` and `src`) as additional arguments to `console.error`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
