### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,6 +6,9 @@ on:
   merge_group:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Quality Checks


### PR DESCRIPTION
Potential fix for [https://github.com/chintan992/letsstream2/security/code-scanning/2](https://github.com/chintan992/letsstream2/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow file. This block will be added at the root level of the workflow to apply to all jobs. Since the workflow primarily involves tasks like checking out the repository, installing dependencies, running tests, and uploading artifacts, the minimal required permission is `contents: read`. This ensures that the workflow has only the necessary access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
